### PR TITLE
Dev jd/minor UI

### DIFF
--- a/src/app-web/components/EvidenceNotes.css
+++ b/src/app-web/components/EvidenceNotes.css
@@ -1,0 +1,20 @@
+/* Styles for hyperlink-like buttons */
+.evidence-link {
+    /* Remove button styles */
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: blue; /* Set the color to blue for hyperlink appearance */
+    text-decoration: underline; /* Add underline to simulate hyperlink text */
+  
+    /* Remove hover and focus effects */
+    outline: none;
+  }
+  
+  /* Remove the default button focus outline */
+  .evidence-link:focus {
+    outline: none;
+  }
+  

--- a/src/app-web/components/EvidenceNotes.jsx
+++ b/src/app-web/components/EvidenceNotes.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import UR from '../../system/ursys';
+import './EvidenceNotes.css'; // Import the CSS file for styling
+
+class EvidenceNotes extends React.Component {
+  handleEvidenceClick = (evNumber, evLetter) => {
+    // Convert evNumber to a number
+    const evNumberAsNumber = parseInt(evNumber, 10);
+
+    // Check if evLetter is not null and convert it to a number
+    const evLetterAsNumber = evLetter !== null ? evLetter.charCodeAt(0) - 96 : null;
+
+    UR.Publish('SHOW_EVIDENCE_LINK', { evId: evLetterAsNumber, rsrcId: evNumberAsNumber });
+  };
+
+  render() {
+    const { comment } = this.props || '';
+    const evidencePattern = /\[Evidence (\d+)([a-z])?\]/gi;
+
+    if (!comment || !comment.text) {
+      return null;
+    }
+
+    const evidenceMatches = [...comment.text.matchAll(evidencePattern)];
+
+    if (evidenceMatches && evidenceMatches.length > 0) {
+      return (
+        <div>
+          Check out the evidence in this comment:{' '}
+          {evidenceMatches.map((match, index) => {
+            const evNumber = match[1];
+            const evLetter = match[2] || null; // Use null if the letter doesn't exist
+
+            // Check if it's the last button to avoid adding comma and space
+            const isLastButton = index === evidenceMatches.length - 1;
+
+            return (
+              <React.Fragment key={index}>
+                <button
+                  className="evidence-link" // Add the CSS class for hyperlink-like style
+                  onClick={() => this.handleEvidenceClick(evNumber, evLetter)}
+                >
+                  {evNumber}
+                  {evLetter}
+                </button>
+                {/* Add comma and space if it's not the last button */}
+                {!isLastButton && ', '}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          Consider adding key evidence by writing [Evidence #] where # is the evidence ID you want
+          people to look at.
+        </div>
+      );
+    }
+  }
+}
+
+export default EvidenceNotes;

--- a/src/app-web/components/EvidenceNotes.jsx
+++ b/src/app-web/components/EvidenceNotes.jsx
@@ -38,7 +38,7 @@ class EvidenceNotes extends React.Component {
     if (evidenceMatches && evidenceMatches.length > 0) {
       return (
         <div>
-          Check out the evidence in this comment:{' '}
+          Evidence:{' '}
           {evidenceMatches.map((match, index) => {
             const evNumber = match[1];
             const evLetter = match[2] || null; // Use null if the letter doesn't exist
@@ -63,12 +63,7 @@ class EvidenceNotes extends React.Component {
         </div>
       );
     } else {
-      return (
-        <div>
-          Consider adding key evidence by writing 'Evidence #' where # is the evidence ID you want
-          people to look at.
-        </div>
-      );
+      return <div>Consider pointing out relevant evidence by typing 'evidence #'.</div>;
     }
   }
 }

--- a/src/app-web/components/EvidenceNotes.jsx
+++ b/src/app-web/components/EvidenceNotes.jsx
@@ -26,7 +26,7 @@ class EvidenceNotes extends React.Component {
   };
 
   render() {
-    const { comment } = this.props || '';
+    const { comment, isBeingEdited } = this.props || '';
     const evidencePattern = /Evidence (\d+)([a-z])?/gi;
 
     if (!comment || !comment.text) {
@@ -63,7 +63,11 @@ class EvidenceNotes extends React.Component {
         </div>
       );
     } else {
-      return <div>Consider pointing out relevant evidence by typing 'evidence #'.</div>;
+      return (
+        <div hidden={!isBeingEdited}>
+          Consider pointing out relevant evidence by typing 'evidence #'.
+        </div>
+      );
     }
   }
 }

--- a/src/app-web/components/EvidenceNotes.jsx
+++ b/src/app-web/components/EvidenceNotes.jsx
@@ -1,3 +1,15 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+EvidenceNotes
+
+Joshua whipped this up, so it might need some tightening.
+
+The basic idea is to look for markdown style "Evidence links" in the comment text and a) note it and b) make a link to it.
+
+NOTE: The styling is off / we should be using VBadges but it was too much of a hassle for me to figure out how.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
 import React from 'react';
 import UR from '../../system/ursys';
 import './EvidenceNotes.css'; // Import the CSS file for styling
@@ -15,10 +27,10 @@ class EvidenceNotes extends React.Component {
 
   render() {
     const { comment } = this.props || '';
-    const evidencePattern = /\[Evidence (\d+)([a-z])?\]/gi;
+    const evidencePattern = /Evidence (\d+)([a-z])?/gi;
 
     if (!comment || !comment.text) {
-      return null;
+      return '';
     }
 
     const evidenceMatches = [...comment.text.matchAll(evidencePattern)];
@@ -53,7 +65,7 @@ class EvidenceNotes extends React.Component {
     } else {
       return (
         <div>
-          Consider adding key evidence by writing [Evidence #] where # is the evidence ID you want
+          Consider adding key evidence by writing 'Evidence #' where # is the evidence ID you want
           people to look at.
         </div>
       );

--- a/src/app-web/components/HelpView.jsx
+++ b/src/app-web/components/HelpView.jsx
@@ -146,6 +146,14 @@ Moreland, Vickery, Murphy & Stiso.
           <Divider style={{ marginBottom: '0.5em' }} />
           <div style={{ overflowY: 'scroll', paddingRight: '5px' }}>
             <h6>Criteria for a Good Model</h6>
+            <div>
+              <p>
+                <em>
+                  Don't forget that it's good to point out both the strengths of a model, and the
+                  areas we think can be improved.
+                </em>
+              </p>
+            </div>
             <CriteriaList Criteria={criteria} IsInEditMode={false} />
             <MDReactComponent className={classes.helpViewText} text={helptext} />
             <MDReactComponent className={classes.helpViewText} text={credittext} />

--- a/src/app-web/components/ResourceItem.jsx
+++ b/src/app-web/components/ResourceItem.jsx
@@ -142,7 +142,7 @@ class ResourceItem extends React.Component {
     const { isExpanded, hideAddButton } = this.state;
     let evBadge = {};
     if (!isExpanded) {
-      let links = resource.links || 0;
+      let links = DATA.GetEvLinksCountByResourceId(resource.id);
       evBadge = <Chip className={classes.evidenceBadge} label={links} color="primary" />;
     } else {
       evBadge = '';

--- a/src/app-web/components/StickyNote.jsx
+++ b/src/app-web/components/StickyNote.jsx
@@ -66,6 +66,7 @@ import ADM from '../modules/data';
 import PMC from '../modules/pmc-data';
 import ASET from '../modules/adm-settings';
 import MDReactComponent from 'markdown-react-js';
+import EvidenceNotes from './EvidenceNotes';
 
 /// CLASS DECLARATION /////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -393,6 +394,9 @@ class StickyNote extends React.Component {
                   }}
                   inputRef={this.textInput}
                 />
+                <div>
+                  <EvidenceNotes comment={comment} />
+                </div>
               </MuiThemeProvider>
             </Grid>
           </Grid>

--- a/src/app-web/components/StickyNote.jsx
+++ b/src/app-web/components/StickyNote.jsx
@@ -83,6 +83,7 @@ class StickyNote extends React.Component {
 
     this.DoOpenSticky = this.DoOpenSticky.bind(this);
     this.OnEditClick = this.OnEditClick.bind(this);
+    this.OnSaveClick = this.OnSaveClick.bind(this);
     this.DoEditStart = this.DoEditStart.bind(this);
     this.DoSave = this.DoSave.bind(this);
     this.DoDelete = this.DoDelete.bind(this);
@@ -210,6 +211,10 @@ class StickyNote extends React.Component {
   OnEditClick(e) {
     e.preventDefault();
     this.DoEditStart();
+  }
+
+  OnSaveClick(e) {
+    this.OnEditFinished();
   }
 
   FocusTextInput() {
@@ -396,8 +401,10 @@ class StickyNote extends React.Component {
                   }}
                   inputRef={this.textInput}
                 />
-                <EvidenceNotes comment={comment} />
               </MuiThemeProvider>
+              <div className={classes.stickynoteCardLabel}>
+                <EvidenceNotes comment={comment} />
+              </div>
             </Grid>
           </Grid>
           <Grid container style={{ alignItems: 'flex-end', marginTop: '3px', height: '20px' }}>
@@ -415,8 +422,8 @@ class StickyNote extends React.Component {
               {isBeingEdited ? ( // Render the Save button when in edit mode
                 <IconButton
                   size="small"
-                  hidden={!isBeingEdited}
-                  onClick={this.OnClickAway}
+                  hidden={!(allowedToEdit && isBeingEdited) || selectedCriteria === undefined}
+                  onClick={this.OnSaveClick}
                   className={classes.stickynoteCardEditBtn}
                 >
                   <SaveIcon fontSize="small" className={classes.stickynoteCardAuthor} />

--- a/src/app-web/components/StickyNote.jsx
+++ b/src/app-web/components/StickyNote.jsx
@@ -55,6 +55,8 @@ import Typography from '@material-ui/core/Typography';
 // Material UI Icons
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
+import SaveIcon from '@material-ui/icons/Save';
+
 // Material UI Theming
 import { withStyles, MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
@@ -394,9 +396,7 @@ class StickyNote extends React.Component {
                   }}
                   inputRef={this.textInput}
                 />
-                <div>
-                  <EvidenceNotes comment={comment} />
-                </div>
+                <EvidenceNotes comment={comment} />
               </MuiThemeProvider>
             </Grid>
           </Grid>
@@ -412,14 +412,26 @@ class StickyNote extends React.Component {
               </IconButton>
             </Grid>
             <Grid item xs={1}>
-              <IconButton
-                size="small"
-                hidden={!showEditButtons || (!allowedToEdit || isBeingEdited)}
-                onClick={this.OnEditClick}
-                className={classes.stickynoteCardEditBtn}
-              >
-                <EditIcon fontSize="small" className={classes.stickynoteCardAuthor} />
-              </IconButton>
+              {isBeingEdited ? ( // Render the Save button when in edit mode
+                <IconButton
+                  size="small"
+                  hidden={!isBeingEdited}
+                  onClick={this.OnClickAway}
+                  className={classes.stickynoteCardEditBtn}
+                >
+                  <SaveIcon fontSize="small" className={classes.stickynoteCardAuthor} />
+                </IconButton>
+              ) : (
+                // Render the Edit button when not in edit mode
+                <IconButton
+                  size="small"
+                  hidden={!showEditButtons || (!allowedToEdit || isBeingEdited)}
+                  onClick={this.OnEditClick}
+                  className={classes.stickynoteCardEditBtn}
+                >
+                  <EditIcon fontSize="small" className={classes.stickynoteCardAuthor} />
+                </IconButton>
+              )}
             </Grid>
           </Grid>
         </Paper>

--- a/src/app-web/components/StickyNote.jsx
+++ b/src/app-web/components/StickyNote.jsx
@@ -403,7 +403,7 @@ class StickyNote extends React.Component {
                 />
               </MuiThemeProvider>
               <div className={classes.stickynoteCardLabel}>
-                <EvidenceNotes comment={comment} />
+                <EvidenceNotes comment={comment} isBeingEdited={isBeingEdited} />
               </div>
             </Grid>
           </Grid>

--- a/src/app-web/modules/defaults.js
+++ b/src/app-web/modules/defaults.js
@@ -60,7 +60,7 @@ const DEFAULTS = {
     STICKY_BUTTON: '#ffdd11'
   },
   TEXT: {
-    ADD_EVIDENCE: 'Link Evidence'
+    ADD_EVIDENCE: 'New Evidence Link'
   }
 };
 

--- a/src/app-web/modules/pmc-data.js
+++ b/src/app-web/modules/pmc-data.js
@@ -1516,8 +1516,8 @@ PMCData.GetEvLinksByResourceId = rsrcId => {
   return h_evidenceByResource.get(rsrcId);
 };
 
+// Additional helper method to return the link count, as needed in the resource list (and maybe other places?)
 PMCData.GetEvLinksCountByResourceId = rsrcId => {
-  // console.log('evlinks by rsrcId', ...Object.keys(h_evidenceByResource));
   return h_evidenceByResource.get(rsrcId).length;
 };
 

--- a/src/app-web/modules/pmc-data.js
+++ b/src/app-web/modules/pmc-data.js
@@ -1516,6 +1516,11 @@ PMCData.GetEvLinksByResourceId = rsrcId => {
   return h_evidenceByResource.get(rsrcId);
 };
 
+PMCData.GetEvLinksCountByResourceId = rsrcId => {
+  // console.log('evlinks by rsrcId', ...Object.keys(h_evidenceByResource));
+  return h_evidenceByResource.get(rsrcId).length;
+};
+
 /// DEBUG UTILS //////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if (!window.ur) window.ur = {};


### PR DESCRIPTION
Renamed evidence link
Fixed evidence count badge on resource panel
Tweaked comments to include dynamic feedback on whether evidence is referenced 

The way the comments now work:

1. Select a comment criteria - the space below the text box is empty.
2. Begin typing, it now suggests adding evidence ("Consider pointing out relevant evidence by typing evidence # ")
3. If you hit save, the suggestion goes away.
4. If you type anything that includes evidence # (e.g., I think you should read evidence 7" then the space below the text box now displays Evidence # or Evidence #, # for each number of evidence that is referenced. Those are now hyperlinked to open evidence in the right-hand panel.

Note, there is no verification that the evidence actually exists.