### PR TITLE
Simplify evidence

### DIFF
--- a/src/app-web/components/EvidenceLink.jsx
+++ b/src/app-web/components/EvidenceLink.jsx
@@ -577,8 +577,8 @@ class EvidenceLink extends React.Component {
     } = this.state;
     if (id === '') return '';
 
-    let sourceType = undefined;
-    let sourceLabel = undefined;
+    let sourceType;
+    let sourceLabel;
     // If we are listeningForSourceSelection, then leave sourceType and sourceLabel
     // undefined so that the link button will show "Click on Target"
     // otherwise show the prop or mech linked.
@@ -606,48 +606,48 @@ class EvidenceLink extends React.Component {
 
     // IDEA
     const Idea = (
-                <Grid
-                  container
-                  spacing={1}
+      <Grid
+        container
+        spacing={1}
         className={isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRowCollapsed}
-                    >
+      >
         <Grid item xs={4} hidden={!isExpanded} className={classes.evidenceWindowLabelGrid}>
           <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
-                      IDEA:
-                    </Typography>
-                  </Grid>
+            IDEA:
+          </Typography>
+        </Grid>
 
-                  <Grid item xs>
-                    {isExpanded ? (
-                      <MuiThemeProvider theme={theme}>
-                        <FilledInput
-                          className={ClassNames(
-                            classes.evidenceLabelField,
-                            classes.evidenceLabelFieldExpanded
-                          )}
-                          value={note}
-                          placeholder="One idea from this evidence..."
-                          autoFocus
-                          multiline
-                          variant="filled"
-                          disabled={!isBeingEdited}
-                          disableUnderline
-                          onChange={this.OnNoteChange}
-                          onBlur={this.OnBlur}
-                          onClick={e => {
-                            e.stopPropagation();
-                          }}
-                          inputProps={{
-                            readOnly: !isBeingEdited
-                          }}
-                          inputRef={this.textInputRef}
-                        />
-                      </MuiThemeProvider>
-                    ) : (
-                      <div className={classes.evidenceLabelField}>{note}</div>
-                    )}
-                  </Grid>
-                </Grid>
+        <Grid item xs>
+          {isExpanded ? (
+            <MuiThemeProvider theme={theme}>
+              <FilledInput
+                className={ClassNames(
+                  classes.evidenceLabelField,
+                  classes.evidenceLabelFieldExpanded
+                )}
+                value={note}
+                placeholder="One idea from this evidence..."
+                autoFocus
+                multiline
+                variant="filled"
+                disabled={!isBeingEdited}
+                disableUnderline
+                onChange={this.OnNoteChange}
+                onBlur={this.OnBlur}
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+                inputProps={{
+                  readOnly: !isBeingEdited
+                }}
+                inputRef={this.textInputRef}
+              />
+            </MuiThemeProvider>
+          ) : (
+            <div className={classes.evidenceLabelField}>{note}</div>
+          )}
+        </Grid>
+      </Grid>
     );
 
     // SCREENSHOT
@@ -691,144 +691,144 @@ class EvidenceLink extends React.Component {
           (Not linked to model yet)
         </Typography>
       ) : (
-                <Grid item xs={12}>
-                  <Grid
-                    container
-                    spacing={1}
-          className={isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRowCollapsed}
-                      >
-          <Grid item xs={4} hidden={!isExpanded} className={classes.evidenceWindowLabelGrid}>
-            <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
-                        TARGET:
-                      </Typography>
-                    </Grid>
-                    <Grid item xs>
-                      <div className={classes.evidenceLinkAvatar}>
-                        <LinkButton
-                          sourceType={sourceType}
-                          sourceLabel={sourceLabel}
-                          listenForSourceSelection={listenForSourceSelection}
-                          isBeingEdited={isBeingEdited}
-                          isExpanded={isExpanded}
-                          OnLinkButtonClick={this.OnLinkButtonClick}
-                        />
-                      </div>
-                    </Grid>
-                  </Grid>
-                </Grid>
-    );
+        <Grid item xs={12}>
+          <Grid
+            container
+            spacing={1}
+            className={isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRowCollapsed}
+          >
+            <Grid item xs={4} hidden={!isExpanded} className={classes.evidenceWindowLabelGrid}>
+              <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
+                TARGET:
+              </Typography>
+            </Grid>
+            <Grid item xs>
+              <div className={classes.evidenceLinkAvatar}>
+                <LinkButton
+                  sourceType={sourceType}
+                  sourceLabel={sourceLabel}
+                  listenForSourceSelection={listenForSourceSelection}
+                  isBeingEdited={isBeingEdited}
+                  isExpanded={isExpanded}
+                  OnLinkButtonClick={this.OnLinkButtonClick}
+                />
+              </div>
+            </Grid>
+          </Grid>
+        </Grid>
+      );
 
     // RATING -- show only if TARGET is defined
     const Rating = sourceType && (
-              <Grid item xs={isExpanded ? 12 : 3}>
-                <Grid
-                  container
-                  spacing={1}
+      <Grid item xs={isExpanded ? 12 : 3}>
+        <Grid
+          container
+          spacing={1}
           className={isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRatingCollapsed}
-                    >
+        >
           <Grid item xs={4} hidden={!isExpanded} className={classes.evidenceWindowLabelGrid}>
             <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
-                      RATING:
-                    </Typography>
-                  </Grid>
-                  <Grid item xs style={{ paddingTop: isExpanded ? '4px' : '19px' }}>
-                    <RatingButton
-                      rating={rating}
-                      isExpanded={isExpanded}
-                      disabled={isViewOnly}
-                      ratingLabel=""
-                      ratingDefs={ratingDefs}
-                      OnRatingButtonClick={this.OnRatingButtonClick}
-                    />
-                  </Grid>
-                </Grid>
-              </Grid>
+              RATING:
+            </Typography>
+          </Grid>
+          <Grid item xs style={{ paddingTop: isExpanded ? '4px' : '19px' }}>
+            <RatingButton
+              rating={rating}
+              isExpanded={isExpanded}
+              disabled={isViewOnly}
+              ratingLabel=""
+              ratingDefs={ratingDefs}
+              OnRatingButtonClick={this.OnRatingButtonClick}
+            />
+          </Grid>
+        </Grid>
+      </Grid>
     );
 
     // REASON -- show only if TARGET is defined
     const Reason = sourceType && (
-              <Grid item xs={12} hidden={!isExpanded}>
-                <Grid container spacing={1} className={classes.evidenceBodyRow}>
-                  <Grid item xs={4} className={classes.evidenceWindowLabelGrid}>
+      <Grid item xs={12} hidden={!isExpanded}>
+        <Grid container spacing={1} className={classes.evidenceBodyRow}>
+          <Grid item xs={4} className={classes.evidenceWindowLabelGrid}>
             <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
-                      REASON
-                    </Typography>
-                  </Grid>
-                  <Grid item xs style={{ paddingTop: '4px' }}>
-                    <MuiThemeProvider theme={theme}>
-                      <FilledInput
-                        className={ClassNames(
-                          classes.evidenceLabelField,
-                          classes.evidenceLabelFieldExpanded
-                        )}
-                        value={why}
-                        placeholder="Why did you choose this rating?"
-                        autoFocus
-                        multiline
-                        variant="filled"
-                        disabled={!isBeingEdited}
-                        disableUnderline
-                        onChange={this.OnWhyChange}
-                        onBlur={this.OnBlur}
-                        onClick={e => {
-                          e.stopPropagation();
-                        }}
-                        inputProps={{
-                          readOnly: !isBeingEdited
-                        }}
-                        inputRef={this.textInput}
-                      />
-                    </MuiThemeProvider>
-                  </Grid>
-                </Grid>
-              </Grid>
+              REASON
+            </Typography>
+          </Grid>
+          <Grid item xs style={{ paddingTop: '4px' }}>
+            <MuiThemeProvider theme={theme}>
+              <FilledInput
+                className={ClassNames(
+                  classes.evidenceLabelField,
+                  classes.evidenceLabelFieldExpanded
+                )}
+                value={why}
+                placeholder="Why did you choose this rating?"
+                autoFocus
+                multiline
+                variant="filled"
+                disabled={!isBeingEdited}
+                disableUnderline
+                onChange={this.OnWhyChange}
+                onBlur={this.OnBlur}
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+                inputProps={{
+                  readOnly: !isBeingEdited
+                }}
+                inputRef={this.textInput}
+              />
+            </MuiThemeProvider>
+          </Grid>
+        </Grid>
+      </Grid>
     );
 
     // CONTROL BAR
     const ControlBar = (
-            <div style={{ display: 'flex', margin: '10px 10px 5px 0' }}>
-              <Button
-                hidden={true || !isExpanded || !isBeingEdited}
-                size="small"
-                onClick={this.OnCancelButtonClick}
-              >
-                cancel
-              </Button>
-              <Button
-                hidden={!isExpanded || isBeingEdited || isViewOnly}
-                size="small"
-                className={classes.btnSuperSmall}
-                onClick={this.OnDeleteButtonClick}
-              >
-                delete
-              </Button>
-              <div style={{ flexGrow: '1' }} />
-              <Button
-                hidden={!isExpanded || isBeingEdited || isViewOnly}
-                size="small"
-                className={classes.btnSuperSmall}
-                onClick={this.OnDuplicateButtonClick}
-              >
-                duplicate
-              </Button>
-              <div style={{ flexGrow: '1' }} />
-              <Button
-                variant="contained"
-                onClick={this.OnEditButtonClick}
-                hidden={!isExpanded || isBeingEdited || isViewOnly}
-                size="small"
-              >
-                Edit
-              </Button>
-              <Button
-                variant="contained"
-                onClick={this.OnSaveButtonClick}
-                hidden={!isExpanded || !isBeingEdited}
-                size="small"
-              >
-                Close
-              </Button>
-            </div>
+      <div style={{ display: 'flex', margin: '10px 10px 5px 0' }}>
+        <Button
+          hidden={true || !isExpanded || !isBeingEdited}
+          size="small"
+          onClick={this.OnCancelButtonClick}
+        >
+          cancel
+        </Button>
+        <Button
+          hidden={!isExpanded || isBeingEdited || isViewOnly}
+          size="small"
+          className={classes.btnSuperSmall}
+          onClick={this.OnDeleteButtonClick}
+        >
+          delete
+        </Button>
+        <div style={{ flexGrow: '1' }} />
+        <Button
+          hidden={!isExpanded || isBeingEdited || isViewOnly}
+          size="small"
+          className={classes.btnSuperSmall}
+          onClick={this.OnDuplicateButtonClick}
+        >
+          duplicate
+        </Button>
+        <div style={{ flexGrow: '1' }} />
+        <Button
+          variant="contained"
+          onClick={this.OnEditButtonClick}
+          hidden={!isExpanded || isBeingEdited || isViewOnly}
+          size="small"
+        >
+          Edit
+        </Button>
+        <Button
+          variant="contained"
+          onClick={this.OnSaveButtonClick}
+          hidden={!isExpanded || !isBeingEdited}
+          size="small"
+        >
+          Close
+        </Button>
+      </div>
     );
 
     return (

--- a/src/app-web/components/EvidenceLink.jsx
+++ b/src/app-web/components/EvidenceLink.jsx
@@ -685,7 +685,12 @@ class EvidenceLink extends React.Component {
     );
 
     // TARGET
-    const Target = (
+    const Target =
+      sourceType === undefined && !isBeingEdited ? (
+        <Typography className={classes.evidenceWindowLabel} variant="caption">
+          (Not linked to model yet)
+        </Typography>
+      ) : (
                 <Grid item xs={12}>
                   <Grid
                     container

--- a/src/app-web/components/EvidenceLink.jsx
+++ b/src/app-web/components/EvidenceLink.jsx
@@ -90,9 +90,10 @@ Triggers to save data happens in multiple places:
 /// LIBRARIES /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 import React from 'react';
-import PropTypes from 'prop-types';
-import ClassNames from 'classnames';
-import DATAMAP from '../../system/common-datamap';
+// Material UI Icons
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+// Material UI Theming
+import { withStyles, MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 // Material UI Elements
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
@@ -104,10 +105,10 @@ import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
-// Material UI Icons
-import ExpandLessIcon from '@material-ui/icons/ExpandLess';
-// Material UI Theming
-import { withStyles, MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+// MEME
+import PropTypes from 'prop-types';
+import ClassNames from 'classnames';
+import DATAMAP from '../../system/common-datamap';
 
 /// COMPONENTS ////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/app-web/components/EvidenceLink.jsx
+++ b/src/app-web/components/EvidenceLink.jsx
@@ -603,66 +603,15 @@ class EvidenceLink extends React.Component {
     const resourceFrameIsVisible = resourceFrame !== null && resourceFrame.clientWidth > 0;
     const extensionIsConnected = EXT.IsConnected();
 
-    return (
-      <ClickAwayListener onClickAway={this.OnClickAway}>
-        <Collapse in={isExpanded} collapsedHeight="70px">
-          <Paper
-            className={ClassNames(
-              classes.evidenceLinkPaper,
-              isExpanded ? classes.evidenceLinkPaperExpanded : '',
-              isBeingEdited ? classes.evidenceLinkPaperEditting : '',
-              isHovered ? classes.evidenceLinkPaperHover : ''
-            )}
-            onClick={this.DoToggleExpanded}
-            ref={this.ref}
-            key={`${rsrcId}`}
-            elevation={isExpanded ? 5 : 1}
-            onMouseEnter={() => this.setState({ isHovered: true })}
-            onMouseLeave={() => this.setState({ isHovered: false })}
-          >
-            {/* Title Bar */}
-            <Button
-              className={classes.evidenceExpandButton}
-              onClick={this.DoToggleExpanded}
-              hidden={!isExpanded || isBeingEdited}
-            >
-              <ExpandLessIcon className={isExpanded ? classes.lessIconCollapsed : ''} />
-            </Button>
-            <Typography className={classes.evidenceWindowLabel} hidden={!isExpanded}>
-              EVIDENCE LINK
-            </Typography>
-            {/* Body */}
-            <Grid container className={classes.evidenceBody} spacing={0}>
-              {/* Number / Comment */}
-              <Grid item xs={isExpanded ? 12 : 2} style={{ height: '30px' }}>
-                <div style={{ position: 'relative', left: '230px' }}>
-                  <StickyNoteButton refId={id} />
-                </div>
-                <Avatar className={classes.evidenceBodyNumber} style={{ top: '-37px' }}>
-                  {evlink.numberLabel}
-                </Avatar>
-              </Grid>
-
-              {/* Source */}
-              <Grid item xs={isExpanded ? 12 : 10}>
+    // IDEA
+    const Idea = (
                 <Grid
                   container
                   spacing={1}
-                  className={
-                    isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRowCollapsed
-                  }
-                >
-                  <Grid
-                    item
-                    xs={4}
-                    hidden={!isExpanded}
-                    className={classes.evidenceWindowLabelGrid}
-                  >
-                    <Typography
-                      className={classes.evidenceWindowLabel}
-                      variant="caption"
-                      align="right"
+        className={isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRowCollapsed}
                     >
+        <Grid item xs={4} hidden={!isExpanded} className={classes.evidenceWindowLabelGrid}>
+          <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
                       IDEA:
                     </Typography>
                   </Grid>
@@ -698,27 +647,52 @@ class EvidenceLink extends React.Component {
                     )}
                   </Grid>
                 </Grid>
+    );
 
-                {/* Source */}
+    // SCREENSHOT
+    let ScreenShotComponent;
+    if (imageURL === undefined || imageURL === null) {
+      if (!isBeingEdited) {
+        // Screenshot not defined yet -- Show message
+        ScreenShotComponent = (
+          <Typography className={classes.evidenceScreenshotStatus}>No Screenshot</Typography>
+        );
+      } else {
+        // Edit: No image selected -- Show dropzone
+        ScreenShotComponent = <Dropzone onDrop={this.OnDrop} />;
+      }
+    } else {
+      // Edit: Image selected -- Show image with click to select
+      ScreenShotComponent = (
+        <Button className={classes.evidenceScreenshotButton} onClick={this.OnScreenShotClick}>
+          <img src={imageURL} alt="screenshot" className={classes.evidenceScreenshot} />
+        </Button>
+      );
+    }
+
+    const ScreenShot = (
+      <Grid container hidden={!isExpanded} className={classes.evidenceBodyRowTop}>
+        <Grid item xs={4} className={classes.evidenceWindowLabelGrid}>
+          <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
+            SCREENSHOT:
+          </Typography>
+        </Grid>
+        <Grid item xs>
+          {ScreenShotComponent}
+        </Grid>
+      </Grid>
+    );
+
+    // TARGET
+    const Target = (
                 <Grid item xs={12}>
                   <Grid
                     container
                     spacing={1}
-                    className={
-                      isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRowCollapsed
-                    }
-                  >
-                    <Grid
-                      item
-                      xs={4}
-                      hidden={!isExpanded}
-                      className={classes.evidenceWindowLabelGrid}
-                    >
-                      <Typography
-                        className={classes.evidenceWindowLabel}
-                        variant="caption"
-                        align="right"
+          className={isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRowCollapsed}
                       >
+          <Grid item xs={4} hidden={!isExpanded} className={classes.evidenceWindowLabelGrid}>
+            <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
                         TARGET:
                       </Typography>
                     </Grid>
@@ -736,27 +710,18 @@ class EvidenceLink extends React.Component {
                     </Grid>
                   </Grid>
                 </Grid>
-              </Grid>
+    );
 
+    // RATING -- show only if TARGET is defined
+    const Rating = sourceType && (
               <Grid item xs={isExpanded ? 12 : 3}>
                 <Grid
                   container
                   spacing={1}
-                  className={
-                    isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRatingCollapsed
-                  }
-                >
-                  <Grid
-                    item
-                    xs={4}
-                    hidden={!isExpanded}
-                    className={classes.evidenceWindowLabelGrid}
-                  >
-                    <Typography
-                      className={classes.evidenceWindowLabel}
-                      variant="caption"
-                      align="right"
+          className={isExpanded ? classes.evidenceBodyRow : classes.evidenceBodyRatingCollapsed}
                     >
+          <Grid item xs={4} hidden={!isExpanded} className={classes.evidenceWindowLabelGrid}>
+            <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
                       RATING:
                     </Typography>
                   </Grid>
@@ -772,14 +737,14 @@ class EvidenceLink extends React.Component {
                   </Grid>
                 </Grid>
               </Grid>
+    );
+
+    // REASON -- show only if TARGET is defined
+    const Reason = sourceType && (
               <Grid item xs={12} hidden={!isExpanded}>
                 <Grid container spacing={1} className={classes.evidenceBodyRow}>
                   <Grid item xs={4} className={classes.evidenceWindowLabelGrid}>
-                    <Typography
-                      className={classes.evidenceWindowLabel}
-                      variant="caption"
-                      align="right"
-                    >
+            <Typography className={classes.evidenceWindowLabel} variant="caption" align="right">
                       REASON
                     </Typography>
                   </Grid>
@@ -811,52 +776,10 @@ class EvidenceLink extends React.Component {
                   </Grid>
                 </Grid>
               </Grid>
-              <Grid container hidden={!isExpanded} className={classes.evidenceBodyRowTop}>
-                <Grid item xs={4} className={classes.evidenceWindowLabelGrid}>
-                  <Typography
-                    className={classes.evidenceWindowLabel}
-                    variant="caption"
-                    align="right"
-                  >
-                    SCREENSHOT:
-                  </Typography>
-                </Grid>
-                <Grid item xs>
-                  {imageURL === undefined || imageURL === null ? (
-                    isBeingEdited ? (
-                      <Dropzone onDrop={this.OnDrop} />
-                    ) : (
-                      <Typography className={classes.evidenceScreenshotStatus}>
-                        No Screenshot
-                      </Typography>
-                    )
-                  ) : (
-                    <Button
-                      className={classes.evidenceScreenshotButton}
-                      onClick={this.OnScreenShotClick}
-                    >
-                      <img src={imageURL} alt="screenshot" className={classes.evidenceScreenshot} />
-                    </Button>
-                  )}
-                  {resourceFrameIsVisible && extensionIsConnected ? (
-                    <Button
-                      onClick={this.OnCaptureScreenShotClick}
-                      size="small"
-                      className={classes.btnSuperSmall}
-                    >
-                      Capture Screenshot
-                    </Button>
-                  ) : extensionIsConnected ? (
-                    <Typography className={classes.evidenceScreenshotStatus}>
-                      Open Evidence to Capture Screen
-                    </Typography>
-                  ) : (
-                    ''
-                  )}
-                </Grid>
-              </Grid>
-            </Grid>
-            <Divider style={{ margin: '10px' }} hidden={!isExpanded} />
+    );
+
+    // CONTROL BAR
+    const ControlBar = (
             <div style={{ display: 'flex', margin: '10px 10px 5px 0' }}>
               <Button
                 hidden={true || !isExpanded || !isBeingEdited}
@@ -900,6 +823,58 @@ class EvidenceLink extends React.Component {
                 Close
               </Button>
             </div>
+    );
+
+    return (
+      <ClickAwayListener onClickAway={this.OnClickAway}>
+        <Collapse in={isExpanded} collapsedHeight="70px">
+          <Paper
+            className={ClassNames(
+              classes.evidenceLinkPaper,
+              isExpanded ? classes.evidenceLinkPaperExpanded : '',
+              isBeingEdited ? classes.evidenceLinkPaperEditting : '',
+              isHovered ? classes.evidenceLinkPaperHover : ''
+            )}
+            onClick={this.DoToggleExpanded}
+            ref={this.ref}
+            key={`${rsrcId}`}
+            elevation={isExpanded ? 5 : 1}
+            onMouseEnter={() => this.setState({ isHovered: true })}
+            onMouseLeave={() => this.setState({ isHovered: false })}
+          >
+            {/* Title Bar ----------------------------------------------------------- */}
+            <Button
+              className={classes.evidenceExpandButton}
+              onClick={this.DoToggleExpanded}
+              hidden={!isExpanded || isBeingEdited}
+            >
+              <ExpandLessIcon className={isExpanded ? classes.lessIconCollapsed : ''} />
+            </Button>
+            <Typography className={classes.evidenceWindowLabel} hidden={!isExpanded}>
+              EVIDENCE LINK
+            </Typography>
+            {/* Body  ---------------------------------------------------------------*/}
+            <Grid container className={classes.evidenceBody} spacing={0}>
+              {/* Number / Comment */}
+              <Grid item xs={isExpanded ? 12 : 2} style={{ height: '30px' }}>
+                <div style={{ position: 'relative', left: '230px' }}>
+                  <StickyNoteButton refId={id} />
+                </div>
+                <Avatar className={classes.evidenceBodyNumber} style={{ top: '-37px' }}>
+                  {evlink.numberLabel}
+                </Avatar>
+              </Grid>
+              <Grid item xs={isExpanded ? 12 : 10}>
+                {Idea}
+                {ScreenShot}
+                {Target}
+              </Grid>
+              {Rating}
+              {Reason}
+            </Grid>
+            <Divider style={{ margin: '10px' }} hidden={!isExpanded} />
+            {/* Contro Bar  -------------------------------------------------------- */}
+            {ControlBar}
           </Paper>
         </Collapse>
       </ClickAwayListener>

--- a/src/app-web/components/MEMEStyles.jsx
+++ b/src/app-web/components/MEMEStyles.jsx
@@ -190,7 +190,8 @@ const styles = theme => {
     resourceList: {
       height: '100%',
       width: m_resourceListWidth,
-      overflow: 'hidden',
+      overflowX: 'hidden',
+      overflowY: 'visible',
       backgroundColor: teal[50],
       zIndex: m_zResourceList // above drawer, below modal
     },
@@ -200,7 +201,7 @@ const styles = theme => {
     },
     resourceListList: {
       height: '100%',
-      overflowY: 'auto',
+      overflowY: 'visible',
       backgroundColor: teal[50],
       marginTop: `${m_navbarHeight}px`,
       paddingTop: '0'

--- a/src/app-web/components/ResourceView.jsx
+++ b/src/app-web/components/ResourceView.jsx
@@ -266,6 +266,7 @@ class ResourceView extends React.Component {
             title="resource"
           />
           <div className={classes.resourceViewSidebar}>
+            {/* Hide Note Field per #141
             <TextField
               id="informationNote"
               label="Our Notes"
@@ -279,7 +280,7 @@ class ResourceView extends React.Component {
               disabled={noteIsDisabled}
               onChange={this.OnNoteChange}
               onBlur={this.OnNoteSave}
-            />
+            /> */}
             <Typography variant="caption">OUR EVIDENCE LINKS</Typography>
             <div className={classes.resourceViewSidebarEvidenceList}>
               <EvidenceList rsrcId={resource.id} />

--- a/src/system/ursys.js
+++ b/src/system/ursys.js
@@ -38,8 +38,10 @@ let MEMEXT_INSTALLED = false;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// do session overrides  React does first render in phase after CONFIGURE
 EXEC.Hook(__dirname, 'CONFIGURE', () => {
+  // 2024-0116 Update: MEME screenshot extension is no longer necessary.  #133
   // attempt to connect to extension
-  EXT.ConnectToExtension(SocketUADDR());
+  // EXT.ConnectToExtension(SocketUADDR());
+
   // set SESSION.ReadOnly mode
   if (NetMessage.IsReadOnly()) SESSION.SetDBReadOnly();
   // check for admin override thenreturn


### PR DESCRIPTION
Implements #141 

* The Evidence "Notes" field is now removed.
* Evidence "Idea" and "ScreenShot" are shown by default.  (And "Target" so that you can select a target).
* After selecting a target, "Rating" and "Reason" are displayed and can be edited.

Also fixes #133 
* MEME Screenshot Extension no longer tries to connect (left the code in place in case we add another extension)